### PR TITLE
add defaultProps in REACT_STATICS

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@
 var REACT_STATICS = {
     childContextTypes: true,
     contextTypes: true,
+    defaultProps: true,
     displayName: true,
     getDefaultProps: true,
     mixins: true,


### PR DESCRIPTION
https://github.com/facebook/react/blob/0.13-stable/src/classic/element/ReactElement.js#L184-L191
`defaultProps` of `targetComponent` will be overwritten by `sourceComponent`'s.
add `defaultProps` in `REACT_STATICS`.

The case is if `targetComponent` relay on defaultProps without error handling, will cause error.