### PR TITLE
add type

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,8 @@ var REACT_STATICS = {
     displayName: true,
     getDefaultProps: true,
     mixins: true,
-    propTypes: true
+    propTypes: true,
+    type: true
 };
 
 module.exports = function hoistNonReactStatics(targetComponent, sourceComponent) {


### PR DESCRIPTION
just like previous fix, seems that type contain some important information that if we copy that we will get higher order component be skipped with `react-0.12`

@mridgway