### PR TITLE
Available for decorator syntax

### DIFF
--- a/decorator.js
+++ b/decorator.js
@@ -1,0 +1,13 @@
+/**
+ * Copyright 2015, Yahoo! Inc.
+ * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
+ */
+'use strict';
+
+var hoistNonReactStatics = require('./index');
+
+module.exports = function hoistNonReactStaticsFrom(sourceComponent) {
+  return function(targetComponent) {
+    return hoistNonReactStatics(targetComponent, sourceComponent);
+  }
+};

--- a/tests/unit/index.js
+++ b/tests/unit/index.js
@@ -4,6 +4,7 @@
 var expect = require('chai').expect;
 var React = require('react');
 var hoistNonReactStatics = require('../../index');
+var hoistNonReactStaticsFrom = require('../../decorator');
 
 describe('hoist-non-react-statics', function () {
 
@@ -26,6 +27,34 @@ describe('hoist-non-react-statics', function () {
         });
 
         hoistNonReactStatics(Wrapper, Component);
+
+        expect(Wrapper.displayName).to.equal('Bar');
+        expect(Wrapper.foo).to.equal('bar');
+    });
+
+});
+
+describe('hoist-non-react-statics-from', function () {
+
+    it('should hoist non react statics', function () {
+        var Component = React.createClass({
+            displayName: 'Foo',
+            statics: {
+                foo: 'bar'
+            },
+            render: function () {
+                return null;
+            }
+        });
+
+        var Wrapper = React.createClass({
+            displayName: 'Bar',
+            render: function () {
+                return <Component />;
+            }
+        });
+
+        hoistNonReactStaticsFrom(Component)(Wrapper);
 
         expect(Wrapper.displayName).to.equal('Bar');
         expect(Wrapper.foo).to.equal('bar');


### PR DESCRIPTION
like this.

``` js
import hoistNonReactStaticsFrom from 'hoist-non-react-statics/decorator';

import InnerComponent from 'path/to/file';

@hoistNonReactStaticsFrom(InnerComponent)
export default class WrapperComponent extends React.Component {
    render() {
        return <InnerComponent {...this.props} />;
    }
}
```
