### PR TITLE
Do not hoist properties from string components

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,13 +25,15 @@ var KNOWN_STATICS = {
 };
 
 module.exports = function hoistNonReactStatics(targetComponent, sourceComponent) {
-    var keys = Object.getOwnPropertyNames(sourceComponent);
-    for (var i=0; i<keys.length; ++i) {
-        if (!REACT_STATICS[keys[i]] && !KNOWN_STATICS[keys[i]]) {
-            try {
-                targetComponent[keys[i]] = sourceComponent[keys[i]];
-            } catch (error) {
+    if (typeof sourceComponent !== 'string') { // don't hoist over string (html) components
+        var keys = Object.getOwnPropertyNames(sourceComponent);
+        for (var i=0; i<keys.length; ++i) {
+            if (!REACT_STATICS[keys[i]] && !KNOWN_STATICS[keys[i]]) {
+                try {
+                    targetComponent[keys[i]] = sourceComponent[keys[i]];
+                } catch (error) {
 
+                }
             }
         }
     }

--- a/tests/unit/index.js
+++ b/tests/unit/index.js
@@ -31,4 +31,16 @@ describe('hoist-non-react-statics', function () {
         expect(Wrapper.foo).to.equal('bar');
     });
 
+    it('should not hoist statics from strings', function() {
+        var Component = 'input';
+        var Wrapper = React.createClass({
+            render: function() {
+                return <Component />;
+            }
+        });
+
+        hoistNonReactStatics(Wrapper, Component);
+        expect(Wrapper[0]).to.equal(undefined); // if hoisting it would equal 'i'
+    });
+
 });


### PR DESCRIPTION
Ran into this problem with some higher order components wrapping plain string components.
`Object.getOwnPropertyNames` ran on a string, such as `Object.getOwnPropertyNames('div')` outputs: `["0", "1", "2", "length"]`, and copies over those properties. This PR avoids copying properties from strings.