### PR TITLE
Adds support for copying static symbol properties.

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ var KNOWN_STATICS = {
 
 module.exports = function hoistNonReactStatics(targetComponent, sourceComponent, customStatics) {
     if (typeof sourceComponent !== 'string') { // don't hoist over string (html) components
-        var keys = Object.getOwnPropertyNames(sourceComponent);
+        var keys = Object.getOwnPropertyNames(sourceComponent).concat(Object.getOwnPropertySymbols(sourceComponent));
         for (var i = 0; i < keys.length; ++i) {
             if (!REACT_STATICS[keys[i]] && !KNOWN_STATICS[keys[i]] && (!customStatics || !customStatics[keys[i]])) {
                 try {

--- a/index.js
+++ b/index.js
@@ -24,9 +24,17 @@ var KNOWN_STATICS = {
     arity: true
 };
 
+var isGetOwnPropertySymbolsAvailable = typeof Object.getOwnPropertySymbols === 'function';
+
 module.exports = function hoistNonReactStatics(targetComponent, sourceComponent, customStatics) {
     if (typeof sourceComponent !== 'string') { // don't hoist over string (html) components
-        var keys = Object.getOwnPropertyNames(sourceComponent).concat(Object.getOwnPropertySymbols(sourceComponent));
+        var keys = Object.getOwnPropertyNames(sourceComponent);
+
+        /* istanbul ignore else */
+        if (isGetOwnPropertySymbolsAvailable) {
+            keys = keys.concat(Object.getOwnPropertySymbols(sourceComponent));
+        }
+
         for (var i = 0; i < keys.length; ++i) {
             if (!REACT_STATICS[keys[i]] && !KNOWN_STATICS[keys[i]] && (!customStatics || !customStatics[keys[i]])) {
                 try {

--- a/tests/unit/index.js
+++ b/tests/unit/index.js
@@ -65,4 +65,28 @@ describe('hoist-non-react-statics', function () {
         expect(Wrapper[0]).to.equal(undefined); // if hoisting it would equal 'i'
     });
 
+    it('should hoist symbols', function() {
+        var foo = Symbol('foo');
+
+        var Component = React.createClass({
+            render: function() {
+                return null;
+            }
+        });
+
+        // Manually set static property using Symbol
+        // since React.createClass doesn't handle symbols passed to static
+        Component[foo] = 'bar';
+
+        var Wrapper = React.createClass({
+            render: function() {
+                return <Component />;
+            }
+        });
+
+        hoistNonReactStatics(Wrapper, Component);
+
+        expect(Wrapper[foo]).to.equal('bar');
+    });
+
 });


### PR DESCRIPTION
Support copying symbol properties to make this function more `Object.assign` like.

Native `Object.assign` copies both string and symbol properties. [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign).

This might be useful when wrapped component was annotated using Symbol to exclude name collision.