### PR TITLE
add valid license to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,12 +13,7 @@
     "test": "mocha tests/unit/ --recursive --compilers js:babel/register --reporter spec"
   },
   "author": "Michael Ridgway <mridgway@yahoo-inc.com>",
-  "licenses": [
-    {
-      "type": "BSD",
-      "url": "https://github.com/mridgway/hoist-non-react-statics/blob/master/LICENSE.md"
-    }
-  ],
+  "license": "BSD-3-Clause",
   "devDependencies": {
     "babel": "^5.0.7",
     "babel-eslint": "^3.0.1",


### PR DESCRIPTION
As documented on the NPM documentation (https://docs.npmjs.com/files/package.json#license). The license field has to comply with the SPDX specification for communicating the licenses and copyrights associated with a software package.

From the `LICENSE.md`, I got, that you are using `BSD-3-Clause`.

Merging this PR would improve a lot of lives, as parsing SPDX expressions is much easier than everything else.

Thank you for your time 👍 