### PR TITLE
Modernize eslint config

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,4 @@
 ---
-  parser: "babel-eslint"
   env:
     node: true
   rules:

--- a/.eslintrc
+++ b/.eslintrc
@@ -8,6 +8,6 @@
     no-unused-vars: 0 // see https://github.com/babel/babel-eslint/issues/21
     no-underscore-dangle: 0
     yoda: 0
-    no-alert: false
-    new-cap: false
+    no-alert: 0
+    new-cap: 0
     no-empty-class: 0

--- a/package.json
+++ b/package.json
@@ -16,10 +16,9 @@
   "license": "BSD-3-Clause",
   "devDependencies": {
     "babel": "^5.0.7",
-    "babel-eslint": "^3.0.1",
     "chai": "^3.0.0",
     "coveralls": "^2.11.1",
-    "eslint": "^0.21.0",
+    "eslint": "^3.8.0",
     "istanbul": "^0.3.2",
     "mocha": "^2.0.1",
     "pre-commit": "^1.0.7",


### PR DESCRIPTION
Although ESLint doesn't test linting rules for any files within `node_modules`, it can still fall over `.eslintrc` config files within `node_modules` that it perceives as invalid, and it looks like the rules have become stricter and `false` is no longer accepted. Instead, you now get an error like this:

~~~
/Users/dchamb/dev/hoist-non-react-statics/.eslintrc:
	Configuration for rule "no-alert" is invalid:
	Severity should be one of the following: 0 = off, 1 = warn, 2 = error (you passed 'false').

Error: /Users/dchamb/dev/hoist-non-react-statics/.eslintrc:
	Configuration for rule "no-alert" is invalid:
	Severity should be one of the following: 0 = off, 1 = warn, 2 = error (you passed 'false').
~~~

Although it could be argued that ESLint should support older config even if it was using unsupported flags, modernizing the config was helpful since it actually got rid of the need for 'babel-eslint' as a dependency, which seems like a good thing anyway.