### PR TITLE
Simplify to enumerables + symbols and inherit statics

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,9 @@
 sudo: false
 language: node_js
 node_js:
+  - "8"
   - "6"
   - "4"
-  - "0.12"
-  - "0.10"
 after_success:
   - "npm run cover"
   - "cat artifacts/lcov.info | ./node_modules/coveralls/bin/coveralls.js"

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "babel-cli": "^6.24.1",
     "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-plugin-transform-react-jsx-source": "^6.22.0",
+    "babel-preset-es2015": "^6.24.1",
     "babel-preset-es2016": "^6.24.1",
     "babel-preset-react": "^6.24.1",
     "babel-register": "^6.24.1",

--- a/package.json
+++ b/package.json
@@ -10,17 +10,24 @@
   "scripts": {
     "cover": "node node_modules/istanbul/lib/cli.js cover --dir artifacts -- ./node_modules/mocha/bin/_mocha tests/unit/ --recursive --compilers js:babel/register --reporter spec",
     "lint": "eslint ./index.js",
-    "test": "mocha tests/unit/ --recursive --compilers js:babel/register --reporter spec"
+    "test": "mocha tests/unit/ --recursive --compilers js:babel-register --reporter spec"
   },
   "author": "Michael Ridgway <mridgway@yahoo-inc.com>",
   "license": "BSD-3-Clause",
   "devDependencies": {
-    "babel": "^5.0.7",
-    "chai": "^3.0.0",
+    "babel": "^6.23.0",
+    "babel-cli": "^6.24.1",
+    "babel-plugin-transform-class-properties": "^6.24.1",
+    "babel-plugin-transform-react-jsx-source": "^6.22.0",
+    "babel-preset-es2016": "^6.24.1",
+    "babel-preset-react": "^6.24.1",
+    "babel-register": "^6.24.1",
+    "chai": "^4.0.1",
     "coveralls": "^2.11.1",
+    "create-react-class": "^15.5.3",
     "eslint": "^3.8.0",
-    "istanbul": "^0.3.2",
-    "mocha": "^2.0.1",
+    "istanbul": "^0.4.5",
+    "mocha": "^3.4.2",
     "pre-commit": "^1.0.7",
     "react": "^15.0.0"
   },

--- a/tests/.babelrc
+++ b/tests/.babelrc
@@ -1,0 +1,6 @@
+{
+  "presets": ["react"],
+  "plugins": [
+    "transform-class-properties"
+  ]
+}

--- a/tests/.babelrc
+++ b/tests/.babelrc
@@ -1,5 +1,5 @@
 {
-  "presets": ["react"],
+  "presets": ["es2015", "es2016", "react"],
   "plugins": [
     "transform-class-properties"
   ]

--- a/tests/unit/index.js
+++ b/tests/unit/index.js
@@ -3,12 +3,13 @@
 
 var expect = require('chai').expect;
 var React = require('react');
+var createReactClass = require('create-react-class');
 var hoistNonReactStatics = require('../../index');
 
 describe('hoist-non-react-statics', function () {
 
     it('should hoist non react statics', function () {
-        var Component = React.createClass({
+        var Component = createReactClass({
             displayName: 'Foo',
             statics: {
                 foo: 'bar'
@@ -18,7 +19,7 @@ describe('hoist-non-react-statics', function () {
             }
         });
 
-        var Wrapper = React.createClass({
+        var Wrapper = createReactClass({
             displayName: 'Bar',
             render: function () {
                 return <Component />;
@@ -32,7 +33,7 @@ describe('hoist-non-react-statics', function () {
     });
 
     it('should not hoist custom statics', function () {
-        var Component = React.createClass({
+        var Component = createReactClass({
             displayName: 'Foo',
             statics: {
                 foo: 'bar'
@@ -42,7 +43,7 @@ describe('hoist-non-react-statics', function () {
             }
         });
 
-        var Wrapper = React.createClass({
+        var Wrapper = createReactClass({
             displayName: 'Bar',
             render: function () {
                 return <Component />;
@@ -55,7 +56,7 @@ describe('hoist-non-react-statics', function () {
 
     it('should not hoist statics from strings', function() {
         var Component = 'input';
-        var Wrapper = React.createClass({
+        var Wrapper = createReactClass({
             render: function() {
                 return <Component />;
             }
@@ -68,17 +69,17 @@ describe('hoist-non-react-statics', function () {
     it('should hoist symbols', function() {
         var foo = Symbol('foo');
 
-        var Component = React.createClass({
+        var Component = createReactClass({
             render: function() {
                 return null;
             }
         });
 
         // Manually set static property using Symbol
-        // since React.createClass doesn't handle symbols passed to static
+        // since createReactClass doesn't handle symbols passed to static
         Component[foo] = 'bar';
 
-        var Wrapper = React.createClass({
+        var Wrapper = createReactClass({
             render: function() {
                 return <Component />;
             }
@@ -87,6 +88,29 @@ describe('hoist-non-react-statics', function () {
         hoistNonReactStatics(Wrapper, Component);
 
         expect(Wrapper[foo]).to.equal('bar');
+    });
+
+    it('should inherit class properties', () => {
+        class A extends React.Component {
+            static test3 = 'A';
+            static test4 = 'D';
+            test5 = 'foo';
+        }
+        class B extends A {
+            static test2 = 'B';
+            static test4 = 'DD';
+        }
+        class C {
+            static test1 = 'C';
+        }
+        const D = hoistNonReactStatics(C, B);
+
+
+        expect(D.test1).to.equal('C');
+        expect(D.test2).to.equal('B');
+        expect(D.test3).to.equal('A');
+        expect(D.test4).to.equal('DD');
+        expect(D.test5).to.equal(undefined);
     });
 
 });


### PR DESCRIPTION
This would be a major release (2.0.0) as it no longer hoists non-enumerables and there is new behavior to support hoisting inherited static class properties. 

Resolves #11 and #22.