### PR TITLE
Add support for complex properties

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,10 +16,19 @@ var REACT_STATICS = {
 };
 
 var getOwnPropertySymbols = Object.getOwnPropertySymbols;
+var getOwnPropertyDescriptor = Object.getOwnPropertyDescriptor;
+var defineProperty = Object.defineProperty;
 var hasOwnProperty = Object.prototype.hasOwnProperty;
 var propIsEnumerable = Object.prototype.propertyIsEnumerable;
 var getPrototypeOf = Object.getPrototypeOf;
 var objectPrototype = getPrototypeOf && getPrototypeOf(Object);
+
+function copyProperty(targetComponent, sourceComponent, key) {
+    try { // Avoid failures from read-only properties
+        var descriptor = getOwnPropertyDescriptor(sourceComponent, key);
+        defineProperty(targetComponent, key, descriptor);
+    } catch (e) {}
+}
 
 module.exports = function hoistNonReactStatics(targetComponent, sourceComponent, blacklist) {
     if (typeof sourceComponent !== 'string') { // don't hoist over string (html) components
@@ -34,9 +43,7 @@ module.exports = function hoistNonReactStatics(targetComponent, sourceComponent,
         for (var key in sourceComponent) {
             if (!REACT_STATICS[key] && (!blacklist || !blacklist[key])) {
                 if (hasOwnProperty.call(sourceComponent, key)) {
-                    try { // Avoid failures from read-only properties
-                        targetComponent[key] = sourceComponent[key];
-                    } catch (e) {}
+                    copyProperty(targetComponent, sourceComponent, key);
                 }
             }
         }
@@ -46,9 +53,7 @@ module.exports = function hoistNonReactStatics(targetComponent, sourceComponent,
             for (var i = 0; i < symbols.length; i++) {
                 if (!REACT_STATICS[symbols[i]] && (!blacklist || !blacklist[symbols[i]])) {
                     if (propIsEnumerable.call(sourceComponent, symbols[i])) {
-                        try { // Avoid failures from read-only properties
-                            targetComponent[symbols[i]] = sourceComponent[symbols[i]];
-                        } catch(e) {}
+                        copyProperty(targetComponent, sourceComponent, symbols[i]);
                     }
                 }
             }

--- a/tests/unit/index.js
+++ b/tests/unit/index.js
@@ -90,6 +90,38 @@ describe('hoist-non-react-statics', function () {
         expect(Wrapper[foo]).to.equal('bar');
     });
 
+    it('should hoist properties with accessor methods', function() {
+        var Component = createReactClass({
+            render: function() {
+                return null;
+            }
+        });
+
+        // Manually set static complex property
+        // since createReactClass doesn't handle properties passed to static
+        var counter = 0;
+        Object.defineProperty(Component, 'foo', {
+            enumerable: true,
+            configurable: true,
+            get: function() {
+                return counter++;
+            }
+        });
+
+        var Wrapper = createReactClass({
+            render: function() {
+                return <Component />;
+            }
+        });
+
+        hoistNonReactStatics(Wrapper, Component);
+
+        // Each access of Wrapper.foo should increment counter.
+        expect(Wrapper.foo).to.equal(0);
+        expect(Wrapper.foo).to.equal(1);
+        expect(Wrapper.foo).to.equal(2);
+    });
+
     it('should inherit class properties', () => {
         class A extends React.Component {
             static test3 = 'A';


### PR DESCRIPTION
Simple assignment to copy statics was resulting in loss of behavior for complex properties (i.e., those with getter and setter methods).

This commit switches to using Object.defineProperty() to perform the copy, which preserves the behavior of these complex properties.

In case you're curious, here's a simplified use case that reflects how I discovered this bug. (`Dimensions` is not ready at the time that this file is loaded, which means that these static sizes must be calculated at read time.)

```javascript
import React, {Component} from 'react';
import {Dimensions} from 'react-native';
import Header from './Header';

class Body extends Component {
  static get initialHeight() {
    const headerHeight = Header.initialHeight;
    return Dimensions.get('window').height - headerHeight;
  }

  render() {
    // ...
  }
}
```