### PR TITLE
Adds type definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,9 @@
+declare module 'hoist-non-react-statics' {
+  import React from 'react';
+  function hoistNonReactStatics<Own, Custom>(
+    TargetComponent: React.ComponentType<Own>,
+    SourceComponent: React.ComponentType<Own & Custom>,
+    customStatic?: any): React.ComponentType<Own>;
+
+  export default hoistNonReactStatics;
+}

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "2.1.0",
   "description": "Copies non-react specific statics from a child component to a parent component",
   "main": "index.js",
+  "types": "index.d.ts",
   "repository": {
     "type": "git",
     "url": "git://github.com/mridgway/hoist-non-react-statics.git"


### PR DESCRIPTION
Type definition can now be shipped with the library via npm

`index.d.ts` is the main file with declarations
`package.json` key `types` is pointing to it.

https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html