### PR TITLE
Do nothing if sourceComponent is null/undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ var objectPrototype = getPrototypeOf && getPrototypeOf(Object);
 var getOwnPropertyNames = Object.getOwnPropertyNames;
 
 module.exports = function hoistNonReactStatics(targetComponent, sourceComponent, blacklist) {
-    if (typeof sourceComponent !== 'string') { // don't hoist over string (html) components
+    if (sourceComponent != null && typeof sourceComponent !== 'string') { // don't hoist over string (html) components
 
         if (objectPrototype) {
             var inheritedComponent = getPrototypeOf(sourceComponent);


### PR DESCRIPTION
This PR adds null checking and do nothing if `sourceComponent` is null or undefined. Useful in async component use-case. Otherwise, one might see error like the following.

```
Uncaught TypeError: Cannot convert undefined or null to object
    at getPrototypeOf (<anonymous>)
    at s (index.js:207)
    at index.js:166
    at c (index.js:166)
    at Object.s4tq (routes.js:11)
    at n (bootstrap d447c66…:146)
    at window.webpackJsonp (bootstrap d447c66…:146)
    at main.2609cef….js:1
```

```js
if (objectPrototype) {
  var inheritedComponent = getPrototypeOf(sourceComponent); // <--- error on this line
  if (inheritedComponent && inheritedComponent !== objectPrototype) {
    hoistNonReactStatics(targetComponent, inheritedComponent, blacklist);
  }
}
```