### PR TITLE
TS declaration file is incorrect

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -5,5 +5,5 @@ declare module 'hoist-non-react-statics' {
     SourceComponent: React.ComponentType<Own & Custom>,
     customStatic?: any): React.ComponentType<Own>;
 
-  export default hoistNonReactStatics;
+  export = hoistNonReactStatics;
 }


### PR DESCRIPTION
hoist-non-react-statics does not have a default export and therefore saying `import hoistStatics from 'hoist-non-react-statics';` raises an exception in TS 2.4.1. Because you're using `module.exports` the correct away to require this package in TS is to say `import hoistStatics = require('hoist-non-react-statics');` but that means that the declaration file is incorrect.

Possible fixes:

1. The change proposed here
2. Change the start of [this line](https://github.com/mridgway/hoist-non-react-statics/blob/master/index.js#L35) to `exports.default = modules.exports = ...` and leave the declaration file as it is.