### PR TITLE
Resolve `error TS1192: Module '".../@types/react/index"' has no default export.`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,5 @@
 declare module 'hoist-non-react-statics' {
-  import React from 'react';
+  import * as React from 'react';
   function hoistNonReactStatics<Own, Custom>(
     TargetComponent: React.ComponentType<Own>,
     SourceComponent: React.ComponentType<Own & Custom>,


### PR DESCRIPTION
Currently TS will fail to compile code dependent on `hoist-non-react-statics` without `allowSyntheticDefaultImports` set to `true` (it's `false` be default) in tsconfig.json. This PR fixes that issue.