### PR TITLE
Generalize copying logic by using descriptors

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,12 +25,12 @@ var KNOWN_STATICS = {
   arity: true
 };
 
+var defineProperty = Object.defineProperty;
+var getOwnPropertyNames = Object.getOwnPropertyNames;
 var getOwnPropertySymbols = Object.getOwnPropertySymbols;
-var hasOwnProperty = Object.prototype.hasOwnProperty;
-var propIsEnumerable = Object.prototype.propertyIsEnumerable;
+var getOwnPropertyDescriptor = Object.getOwnPropertyDescriptor;
 var getPrototypeOf = Object.getPrototypeOf;
 var objectPrototype = getPrototypeOf && getPrototypeOf(Object);
-var getOwnPropertyNames = Object.getOwnPropertyNames;
 
 module.exports = function hoistNonReactStatics(targetComponent, sourceComponent, blacklist) {
     if (typeof sourceComponent !== 'string') { // don't hoist over string (html) components
@@ -51,12 +51,10 @@ module.exports = function hoistNonReactStatics(targetComponent, sourceComponent,
         for (var i = 0; i < keys.length; ++i) {
             var key = keys[i];
             if (!REACT_STATICS[key] && !KNOWN_STATICS[key] && (!blacklist || !blacklist[key])) {
-                // Only hoist enumerables and non-enumerable functions
-                if(propIsEnumerable.call(sourceComponent, key) || typeof sourceComponent[key] === 'function') {
-                    try { // Avoid failures from read-only properties
-                        targetComponent[key] = sourceComponent[key];
-                    } catch (e) {}
-                }
+                var descriptor = getOwnPropertyDescriptor(sourceComponent, key);
+                try { // Avoid failures from read-only properties
+                    defineProperty(targetComponent, key, descriptor);
+                } catch (e) {}
             }
         }
 

--- a/tests/unit/index.js
+++ b/tests/unit/index.js
@@ -110,6 +110,38 @@ describe('hoist-non-react-statics', function () {
         expect(Wrapper.test).to.equal(Component.test);
     });
 
+    it('should hoist properties with accessor methods', function() {
+        var Component = createReactClass({
+            render: function() {
+                return null;
+            }
+        });
+
+        // Manually set static complex property
+        // since createReactClass doesn't handle properties passed to static
+        var counter = 0;
+        Object.defineProperty(Component, 'foo', {
+            enumerable: true,
+            configurable: true,
+            get: function() {
+                return counter++;
+            }
+        });
+
+        var Wrapper = createReactClass({
+            render: function() {
+                return <Component />;
+            }
+        });
+
+        hoistNonReactStatics(Wrapper, Component);
+
+        // Each access of Wrapper.foo should increment counter.
+        expect(Wrapper.foo).to.equal(0);
+        expect(Wrapper.foo).to.equal(1);
+        expect(Wrapper.foo).to.equal(2);
+    });
+
     it('should inherit class properties', () => {
         class A extends React.Component {
             static test3 = 'A';


### PR DESCRIPTION
This PR is a revival of #28.

First, it does something simple, which is to use `defineProperty` instead of an equality-based assignment. This is better JS hygiene when copying properties, since equality assignment results in the loss of metadata and can sometimes trigger side-effects.

Second, it removes the enumerable-or-function conditional. Judging by how the 'or-function' was added to this condition only 18 days ago (65f3d58761ea2f987689936101456d2493342ac7), I think we can reasonably agree that this condition is arbitrary. As discussed in my earlier PR (#28), both static functions and complex properties (those with getter/setter methods) are non-enumerable, and both are desirable for hoisting. However, complex properties cannot be 'detected' with a `typeof` operator.

In the end, if we have a complete blacklist (as we do), there should be no harm in copying all non-blacklisted static properties from one component to another, so that's what I'm proposing here.