### PR TITLE
Fix TypeScript definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,9 +1,7 @@
 declare module 'hoist-non-react-statics' {
-  import React from 'react';
-  function hoistNonReactStatics<Own, Custom>(
+  import * as React from 'react';
+  export default function hoistNonReactStatics<Own, Custom>(
     TargetComponent: React.ComponentType<Own>,
     SourceComponent: React.ComponentType<Own & Custom>,
     customStatic?: any): React.ComponentType<Own>;
-
-  export = hoistNonReactStatics;
 }


### PR DESCRIPTION
This fixes 2 issues with the TypeScript definitions:

* Makes it work even if the allowSyntehticDefaultImports is disabled (also fixed by https://github.com/mridgway/hoist-non-react-statics/pull/36)

* Fixes definitions for 2.4, which does not allow `export = ...`