### PR TITLE
modify index.d.ts for typescript module

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,9 @@
 declare module 'hoist-non-react-statics' {
   import * as React from 'react';
-  export default function hoistNonReactStatics<Own, Custom>(
+  function hoistNonReactStatics<Own, Custom>(
     TargetComponent: React.ComponentType<Own>,
     SourceComponent: React.ComponentType<Own & Custom>,
     customStatic?: any): React.ComponentType<Own>;
+    
+  export = hoistNonReactStatics
 }


### PR DESCRIPTION
there is a error when I use typescript to import this module like this 
`import hoistStatics from 'hoist-non-react-statics'`
because `hoistStatics` will point to `require('hoist-non-react-statics').default`
but the `module.exports.default` is undefined.
so we should import the module like this `import * as hoistStatics from 'hoist-non-react-statics'`
so I modify d.ts for typescript type system

