### PR TITLE
change hoistNonReactStatic to hoistNonReactStatics, same as the lib

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ $ npm install --save hoist-non-react-statics
 ## Usage
 
 ```js
-import hoistNonReactStatic from 'hoist-non-react-statics';
+import hoistNonReactStatics from 'hoist-non-react-statics';
 
-hoistNonReactStatic(targetComponent, sourceComponent);
+hoistNonReactStatics(targetComponent, sourceComponent);
 ```
 
 ## What does this module do?


### PR DESCRIPTION
In some other docs, `hoistNonReactStatics ` is used. 

hoistNonReactStatic in this readme may cause some mistaken.