### PR TITLE
Added getDerivedStateFromProps as React static

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ See this [explanation](https://facebook.github.io/react/docs/higher-order-compon
 
 | Compatible React Version | hoist-non-react-statics Version |
 |--------------------------|-------------------------------|
-| 0.13-15.0 | >= 1.0.0 |
+| 0.13-16.0 | >= 1.0.0 |
 
 ## Browser Support
 

--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@
         defaultProps: true,
         displayName: true,
         getDefaultProps: true,
+        getDerivedStateFromProps: true,
         mixins: true,
         propTypes: true,
         type: true


### PR DESCRIPTION
Added `getDerivedStateFromProps`, that [will be released](https://github.com/facebook/react/issues/12152#issuecomment-362957376) with React 16.3, as a React static.