### PR TITLE
Remove unnecessary ambient module declaration.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,9 +1,8 @@
-declare module 'hoist-non-react-statics' {
-  import * as React from 'react';
-  function hoistNonReactStatics<Own, Custom>(
-    TargetComponent: React.ComponentType<Own>,
-    SourceComponent: React.ComponentType<Own & Custom>,
-    customStatic?: any): React.ComponentType<Own>;
-    
-  export = hoistNonReactStatics
-}
+import * as React from 'react';
+
+declare function hoistNonReactStatics<Own, Custom>(
+  TargetComponent: React.ComponentType<Own>,
+  SourceComponent: React.ComponentType<Own & Custom>,
+  customStatic?: any): React.ComponentType<Own>;
+
+export = hoistNonReactStatics


### PR DESCRIPTION
Currently TypeScript will resolve to the `index.d.ts` file, then consider this file to be global, and things will just work because the `declare module 'hoist-non-react-statics'` declaration still gets introduced into the program context. But if the compiler finds another `declare module 'hoist-non-react-statics'`, it may conflict.

Simply making the file itself become a module and letting Node's module resolution strategy take over can prevent global file conflicts. This PR does just that.