### PR TITLE
Fix primary export

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -5,4 +5,4 @@ declare function hoistNonReactStatics<Own, Custom>(
   SourceComponent: React.ComponentType<Own & Custom>,
   customStatic?: any): React.ComponentType<Own>;
 
-export = hoistNonReactStatics
+export default hoistNonReactStatics


### PR DESCRIPTION
The code itself uses "export default" for the primary export, so the type definition should match.
The existing type definition did not permit using the normal default import syntax:
`import hoistNonReactStatics from 'hoist-non-react-statics'`