### PR TITLE
Don't relate source and target prop types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,8 +1,8 @@
 import * as React from 'react';
 
-declare function hoistNonReactStatics<Own, Custom>(
-  TargetComponent: React.ComponentType<Own>,
-  SourceComponent: React.ComponentType<Own & Custom>,
-  customStatic?: any): React.ComponentType<Own>;
+declare function hoistNonReactStatics<T extends React.ComponentType>(
+  TargetComponent: T,
+  SourceComponent: React.ComponentType,
+  customStatic?: any): T;
 
 export default hoistNonReactStatics


### PR DESCRIPTION
There is no need to make any assertion that the prop types of the components are related in any way.