### PR TITLE
Removing "types" key from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "3.0.1",
   "description": "Copies non-react specific statics from a child component to a parent component",
   "main": "dist/hoist-non-react-statics.cjs.js",
-  "types": "index.d.ts",
   "repository": {
     "type": "git",
     "url": "git://github.com/mridgway/hoist-non-react-statics.git"


### PR DESCRIPTION
Since the Typescript types have been removed ( #53 ), this removes the `types` key from package.json. Have a nice day!