### PR TITLE
Add getDerivedStateFromError to the list of known REACT_STATICS

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,7 @@ const REACT_STATICS = {
     defaultProps: true,
     displayName: true,
     getDefaultProps: true,
+    getDerivedStateFromError: true,
     getDerivedStateFromProps: true,
     mixins: true,
     propTypes: true,


### PR DESCRIPTION
- [Added](https://reactjs.org/blog/2018/10/23/react-v-16-6.html#static-getderivedstatefromerror) in `react@16.6.0`
- [documentation](https://reactjs.org/docs/react-component.html#static-getderivedstatefromerror)