### PR TITLE
Remove React peer dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,11 +34,11 @@ See this [explanation](https://facebook.github.io/react/docs/higher-order-compon
 
 ## Compatible React Versions
 
-Please use latest 3.x unless you need to support react@0.13. Versions prior to 3.x will not support ForwardRefs.
+Please use latest 3.x. Versions prior to 3.x will not support ForwardRefs.
 
 | hoist-non-react-statics Version | Compatible React Version |
 |--------------------------|-------------------------------|
-| 3.x | 0.14-16.x With ForwardRef Support |
+| 3.x | 0.13-16.x With ForwardRef Support |
 | 2.x | 0.13-16.x Without ForwardRef Support |
 | 1.x | 0.13-16.2 |
 

--- a/package.json
+++ b/package.json
@@ -26,9 +26,6 @@
   "dependencies": {
     "react-is": "^16.3.2"
   },
-  "peerDependencies": {
-    "react": ">=14.x"
-  },
   "devDependencies": {
     "babel": "^6.23.0",
     "babel-cli": "^6.24.1",

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,6 @@
  * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
  */
 const ReactIs = require('react-is');
-const React = require('react');
 const REACT_STATICS = {
     childContextTypes: true,
     contextType: true,


### PR DESCRIPTION
Fixes #65.

This is no longer a requirement since we do not need to require React anymore.