### PR TITLE
Fix hoisting of react statics between two forwardRef components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# unreleased
+- Fixed `defaultProps`, `displayName` and `propTypes` being hoisted from `React.forwardRef` to `React.forwardRef`. ([#71])
+
 # 3.2.0 (November 26, 2018)
 - Added support for `getDerivedStateFromError`. ([#68])
 - Added support for React versions less than 0.14. ([#69])
@@ -19,5 +22,6 @@
 [#62]: https://github.com/mridgway/hoist-non-react-statics/pull/62
 [#68]: https://github.com/mridgway/hoist-non-react-statics/pull/68
 [#69]: https://github.com/mridgway/hoist-non-react-statics/pull/69
+[#71]: https://github.com/mridgway/hoist-non-react-statics/pull/71
 [e0846fe]: https://github.com/mridgway/hoist-non-react-statics/commit/e0846feefbad8b34d300de9966ffd607aacb81a3
 [e89c7a6]: https://github.com/mridgway/hoist-non-react-statics/commit/e89c7a6168edc19eeadb2d149e600b888e8b0446

--- a/src/index.js
+++ b/src/index.js
@@ -29,7 +29,10 @@ const KNOWN_STATICS = {
 
 const FORWARD_REF_STATICS = {
     '$$typeof': true,
-    render: true
+    render: true,
+    defaultProps: true,
+    displayName: true,
+    propTypes: true
 };
 
 const TYPE_STATICS = {};

--- a/tests/unit/index.js
+++ b/tests/unit/index.js
@@ -226,4 +226,32 @@ describe('hoist-non-react-statics', function () {
         expect(WrappedFancyButton.render).to.not.equal('bar');
     });
 
+    it('should not mix defaultProps, displayName and propTypes in forwardRef', () => {
+        const Component = React.forwardRef((props, ref) => null);
+        Component.defaultProps = {
+            message: 'forwarded'
+        }
+        Component.displayName = 'BaseComponent';
+        Component.propTypes = {
+            id: () => new Error()
+        }
+        Component.foo = 'foo';
+
+        const EnhancedComponent = React.forwardRef(({id, ...props}, ref) => <Component {...props} ref={ref} />);
+        EnhancedComponent.defaultProps = {
+            id: 'stop-me'
+        }
+        EnhancedComponent.displayName = `Enhanced(${Component.displayName})`;
+        EnhancedComponent.propTypes = {
+            innerRef: () => 'deprecated'
+        }
+
+        hoistNonReactStatics(EnhancedComponent, Component);
+
+        expect(EnhancedComponent.foo).to.equal('foo');
+        expect(EnhancedComponent.displayName).to.equal('Enhanced(BaseComponent)');
+        expect(EnhancedComponent.defaultProps.id).to.equal('stop-me');
+        expect(EnhancedComponent.propTypes.innerRef()).to.equal('deprecated');
+    })
+
 });


### PR DESCRIPTION
Closes  #66.

Technically preventing to hoist `propTypes` is wrong for `react < 16.4.1`. Since facebook/react#12911 was introduced in a patch and `propTypes` shouldn't be considered a non-react static anyway this should be fine.