### PR TITLE
Prevent hoisting of React.memo statics

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "author": "Michael Ridgway <mcridgway@gmail.com>",
   "license": "BSD-3-Clause",
   "dependencies": {
-    "react-is": "^16.3.2"
+    "react-is": "^16.7.0"
   },
   "devDependencies": {
     "babel": "^6.23.0",
@@ -44,7 +44,7 @@
     "mocha": "^3.4.2",
     "pre-commit": "^1.0.7",
     "prop-types": "^15.6.2",
-    "react": "^16.3.2",
+    "react": "^16.7.0",
     "rimraf": "^2.6.2",
     "rollup": "^0.52.3",
     "rollup-plugin-babel": "^3.0.4",

--- a/src/index.js
+++ b/src/index.js
@@ -35,8 +35,24 @@ const FORWARD_REF_STATICS = {
     propTypes: true
 };
 
+const MEMO_STATICS = {
+    '$$typeof': true,
+    compare: true,
+    defaultProps: true,
+    displayName: true,
+    propTypes: true,
+    type: true,
+}
+
 const TYPE_STATICS = {};
 TYPE_STATICS[ReactIs.ForwardRef] = FORWARD_REF_STATICS;
+
+function getStatics(component) {
+    if (ReactIs.isMemo(component)) {
+        return MEMO_STATICS;
+    }
+    return TYPE_STATICS[component['$$typeof']] || REACT_STATICS;
+}
 
 const defineProperty = Object.defineProperty;
 const getOwnPropertyNames = Object.getOwnPropertyNames;
@@ -61,8 +77,8 @@ export default function hoistNonReactStatics(targetComponent, sourceComponent, b
             keys = keys.concat(getOwnPropertySymbols(sourceComponent));
         }
 
-        const targetStatics = TYPE_STATICS[targetComponent['$$typeof']] || REACT_STATICS;
-        const sourceStatics = TYPE_STATICS[sourceComponent['$$typeof']] || REACT_STATICS;
+        const targetStatics = getStatics(targetComponent);
+        const sourceStatics = getStatics(sourceComponent);
 
         for (let i = 0; i < keys.length; ++i) {
             const key = keys[i];

--- a/tests/unit/index.js
+++ b/tests/unit/index.js
@@ -260,7 +260,6 @@ describe('hoist-non-react-statics', function () {
 
         function logProps(Component) {
             const LoggedProps = React.forwardRef((props, ref) => {
-                console.log(props);
                 return <Component {...props} ref={ref} />
             })
 

--- a/tests/unit/index.js
+++ b/tests/unit/index.js
@@ -254,4 +254,30 @@ describe('hoist-non-react-statics', function () {
         expect(EnhancedComponent.propTypes.innerRef()).to.equal('deprecated');
     })
 
+    it('should not inherit Memo', () => {
+        const FancyButton = React.memo(props => <button {...props} />);
+        FancyButton.bar = 'bar';
+
+        function logProps(Component) {
+            const LoggedProps = React.forwardRef((props, ref) => {
+                console.log(props);
+                return <Component {...props} ref={ref} />
+            })
+
+            LoggedProps.compare = 'compare';
+            LoggedProps.foo = 'foo';
+
+            hoistNonReactStatics(LoggedProps, Component);
+
+            return LoggedProps;
+        }
+
+        const WrappedFancyButton = logProps(FancyButton);
+
+        expect(WrappedFancyButton.bar).to.equal('bar');
+        expect(WrappedFancyButton.foo).to.equal('foo');
+        expect(WrappedFancyButton.compare).to.equal('compare');
+        expect(WrappedFancyButton.type).to.be.undefined;
+    });
+
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1291,7 +1291,7 @@ fast-levenshtein@~2.0.4:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
 
-fbjs@^0.8.16, fbjs@^0.8.9:
+fbjs@^0.8.9:
   version "0.8.16"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.16.tgz#5e67432f550dc41b572bf55847b8aca64e5337db"
   dependencies:
@@ -2274,14 +2274,6 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.6.0:
-  version "15.6.1"
-  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.1.tgz#36644453564255ddda391191fb3a125cbdf654ca"
-  dependencies:
-    fbjs "^0.8.16"
-    loose-envify "^1.3.1"
-    object-assign "^4.1.1"
-
 prop-types@^15.6.2:
   version "15.6.2"
   resolved "https://registry.npmjs.org/prop-types/-/prop-types-15.6.2.tgz#05d5ca77b4453e985d60fc7ff8c859094a497102"
@@ -2318,18 +2310,20 @@ rc@^1.1.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-is@^16.3.2:
-  version "16.3.2"
-  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.3.2.tgz#f4d3d0e2f5fbb6ac46450641eb2e25bf05d36b22"
+react-is@^16.7.0:
+  version "16.7.0"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.7.0.tgz#c1bd21c64f1f1364c6f70695ec02d69392f41bfa"
+  integrity sha512-Z0VRQdF4NPDoI0tsXVMLkJLiwEBa+RP66g0xDHxgxysxSoCUccSten4RTF/UFvZF1dZvZ9Zu1sx+MDXwcOR34g==
 
-react@^16.3.2:
-  version "16.4.1"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.4.1.tgz#de51ba5764b5dbcd1f9079037b862bd26b82fe32"
+react@^16.7.0:
+  version "16.7.0"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.7.0.tgz#b674ec396b0a5715873b350446f7ea0802ab6381"
+  integrity sha512-StCz3QY8lxTb5cl2HJxjwLFOXPIFQp+p+hxQfc8WE0QiLfCtIlKj8/+5tjjKm8uSTlAW+fCPaavGFS06V9Ar3A==
   dependencies:
-    fbjs "^0.8.16"
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
-    prop-types "^15.6.0"
+    prop-types "^15.6.2"
+    scheduler "^0.12.0"
 
 readable-stream@^2.0.2, readable-stream@^2.0.6, readable-stream@^2.2.2:
   version "2.3.6"
@@ -2527,6 +2521,14 @@ safe-buffer@^5.1.1, safe-buffer@^5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
 sax@^1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
+
+scheduler@^0.12.0:
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.12.0.tgz#8ab17699939c0aedc5a196a657743c496538647b"
+  integrity sha512-t7MBR28Akcp4Jm+QoR63XgAi9YgCUmgvDHqf5otgAj4QvdoBE4ImCX0ffehefePPG+aitiYHp0g/mW6s4Tp+dw==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
 
 semver@^5.3.0:
   version "5.5.0"


### PR DESCRIPTION
[`React.memo` statics](https://github.com/facebook/react/blob/4a1072194fcef2da1aae2510886c274736017fbd/packages/react/src/memo.js#L27-L31)

`ReactIs.isMemo` is working differently than `ReactIs.isForwardRef` which is why we don't have to introspect `$$typeof` here.