### PR TITLE
Additional Check for ReactIs.IsMemo function.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -48,7 +48,7 @@ const TYPE_STATICS = {};
 TYPE_STATICS[ReactIs.ForwardRef] = FORWARD_REF_STATICS;
 
 function getStatics(component) {
-    if (ReactIs.isMemo(component)) {
+    if (ReactIs.isMemo && ReactIs.isMemo(component)) {
         return MEMO_STATICS;
     }
     return TYPE_STATICS[component['$$typeof']] || REACT_STATICS;


### PR DESCRIPTION
Getting this exception when using legacy or older versions of react-is package.
`TypeError: ReactIs.isMemo is not a function`