### PR TITLE
remove unwanted return

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -93,8 +93,6 @@ export default function hoistNonReactStatics(targetComponent, sourceComponent, b
                 } catch (e) {}
             }
         }
-
-        return targetComponent;
     }
 
     return targetComponent;


### PR DESCRIPTION
Looks like we don't need that additional return inside the if statement. Tests pass without it too.