### PR TITLE
Fix `React.memo` for v16.12+

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@
  * Copyright 2015, Yahoo! Inc.
  * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
  */
-import { ForwardRef, isMemo } from 'react-is';
+import { ForwardRef, Memo, isMemo } from 'react-is';
 
 const REACT_STATICS = {
     childContextTypes: true,
@@ -47,11 +47,15 @@ const MEMO_STATICS = {
 
 const TYPE_STATICS = {};
 TYPE_STATICS[ForwardRef] = FORWARD_REF_STATICS;
+TYPE_STATICS[Memo] = MEMO_STATICS;
 
 function getStatics(component) {
+    // React v16.11 and below
     if (isMemo(component)) {
         return MEMO_STATICS;
     }
+
+    // React v16.12 and above
     return TYPE_STATICS[component['$$typeof']] || REACT_STATICS;
 }
 

--- a/tests/unit/index.js
+++ b/tests/unit/index.js
@@ -278,4 +278,23 @@ describe('hoist-non-react-statics', function () {
         expect(WrappedFancyButton.type).to.be.undefined;
     });
 
+    it('should work with memo', () => {
+        const Button = React.memo(props => <button {...props} />);
+        Button.test = 'foo';
+
+        function wrap(Component) {
+          function Wrapper() {
+            return <div><Component /></div>
+          }
+
+          hoistNonReactStatics(Wrapper, Component);
+
+          return Wrapper;
+        }
+
+        const WrappedButton = wrap(Button);
+
+        expect(WrappedButton.type).to.be.undefined;
+        expect(WrappedButton.$$typeof).to.be.undefined;
+    });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2577,14 +2577,14 @@ qs@~6.3.0:
   integrity sha1-51vV9uJoEioqDgvaYwslUMFmUCw=
 
 react-is@^16.7.0, react-is@^16.8.1:
-  version "16.11.0"
-  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.11.0.tgz#b85dfecd48ad1ce469ff558a882ca8e8313928fa"
-  integrity sha512-gbBVYR2p8mnriqAwWx9LbuUrShnAuSCNnuPGyc7GJrMVQtPDAh8iLpv7FRuMPFb56KkaVZIYSz1PrjI9q0QPCw==
+  version "16.12.0"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.12.0.tgz#2cc0fe0fba742d97fd527c42a13bec4eeb06241c"
+  integrity sha512-rPCkf/mWBtKc97aLL9/txD8DZdemK0vkA3JMLShjlJB3Pj3s+lpf1KaBzMfQrAmhMQB0n1cU/SUGgKKBCe837Q==
 
 react@^16.7.0:
-  version "16.11.0"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.11.0.tgz#d294545fe62299ccee83363599bf904e4a07fdbb"
-  integrity sha512-M5Y8yITaLmU0ynd0r1Yvfq98Rmll6q8AxaEe88c8e7LxO8fZ2cNgmFt0aGAS9wzf1Ao32NKXtCl+/tVVtkxq6g==
+  version "16.12.0"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.12.0.tgz#0c0a9c6a142429e3614834d5a778e18aa78a0b83"
+  integrity sha512-fglqy3k5E+81pA8s+7K0/T3DBCF0ZDOher1elBFzF7O6arXJgzyu/FW+COxFvAWXJoJN9KIZbT2LXlukwphYTA==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"


### PR DESCRIPTION
@mridgway 

The `react-is` semantics around memo components changed in v16.12, as seen in this PR: https://github.com/facebook/react/pull/17278

The `isMemo` check in this project no longer passes, which results in invalid wrapped components. For example, before my patch, the `$$typeof` was being copied over, but `type` was not, which crashed `react-test-renderer`.

```
{ Button:
   { '$$typeof': Symbol(react.memo),
     type: [Function],
     compare: null,
     test: 'foo' } }
{ WrappedButton:
   { [Function: Wrapper] '$$typeof': Symbol(react.memo), compare: null, test: 'foo' } }
```

With my patch, the `$$typeof` is no longer copied. It also supports both types of memo checks for the time being.

```
{ Button:
   { '$$typeof': Symbol(react.memo),
     type: [Function],
     compare: null,
     test: 'foo' } }
{ WrappedButton: { [Function: Wrapper] test: 'foo' } }
```

This is kind of a critical bug, and I'm not sure how this hasn't been caught yet.