### PR TITLE
Improved tree shaking in the library by adding sideEffects = false

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "dist",
     "index.d.ts"
   ],
+  "sideEffects": false,
   "scripts": {
     "lint": "eslint src",
     "build": "rimraf dist && rollup -c",


### PR DESCRIPTION
We can hel webpack remove code if we mark package without side effects - https://webpack.js.org/guides/tree-shaking/\#mark-the-file-as-side-effect-free