### PR TITLE
fix(rollup): build umd without react-is

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -19,6 +19,9 @@ const commonjsOptions = {
     'react-is': Object.keys(ReactIs)
   }
 }
+const globals = {
+  'react-is': 'ReactIs',
+};
 
 export default [
   {
@@ -31,7 +34,8 @@ export default [
   },
   {
     input,
-    output: { file: `dist/${pkg.name}.js`, format: 'umd', name },
+    output: { file: `dist/${pkg.name}.js`, format: 'umd', name, globals },
+    external,
     plugins: [
       nodeResolve(),
       babel({ exclude: /node_modules/ }),
@@ -40,7 +44,8 @@ export default [
   },
   {
     input,
-    output: { file: `dist/${pkg.name}.min.js`, format: 'umd', name },
+    output: { file: `dist/${pkg.name}.min.js`, format: 'umd', name, globals },
+    external,
     plugins: [
       nodeResolve(),
       babel({ exclude: /node_modules/ }),


### PR DESCRIPTION
Issue:
can t use hoist-non-react-statics as UMD in a browser: process.env is undefined
https://unpkg.com/browse/hoist-non-react-statics@3.3.2/dist/hoist-non-react-statics.js line 58 we see it
<img width="919" alt="Screenshot 2020-11-17 at 14 32 27" src="https://user-images.githubusercontent.com/19857479/99396201-bc7d1a00-28e1-11eb-83fd-4786d3eba0a9.png">

why:
Current UMD build contains react-is but not ready to be embeded, with process.env in it.

**Proposed Solution** 

update rollup config to rely on react-is globally

UMD build is available for it:
https://unpkg.com/browse/react-is@16.8.6/umd/

This decreases the size of the final build and works well everywhere.