### PR TITLE
fix: remove duplicates react-is when using react 17 and 18

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "author": "Michael Ridgway <mcridgway@gmail.com>",
   "license": "BSD-3-Clause",
   "dependencies": {
-    "react-is": "^16.7.0"
+    "react-is": ">=16"
   },
   "devDependencies": {
     "@babel/core": "^7.5.0",


### PR DESCRIPTION
Hi, I found duplicates version react-is with react 17, so it's small fix can remove that problem for now and future without breaking changes