### PR TITLE
Removing publishConfig

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,9 +46,6 @@
     "rollup-plugin-node-resolve": "^5.2.0",
     "rollup-plugin-terser": "^5.1.1"
   },
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/"
-  },
   "keywords": [
     "react"
   ],


### PR DESCRIPTION
Explicitly specifying that the package be published to https://registry.npmjs.org/ keeps the package from being able to be installed to a private registry. See https://stackoverflow.com/questions/70962883/why-cant-i-publish-this-specific-package-to-a-private-npm-registry-hosted-by-ve.